### PR TITLE
ci: use stable workflow foundation

### DIFF
--- a/.github/workflows/bump-major-version.yml
+++ b/.github/workflows/bump-major-version.yml
@@ -9,6 +9,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-major-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/bump-minor-version.yml
+++ b/.github/workflows/bump-minor-version.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   bump:
-    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.bump-minor-version.yml@v2
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -15,10 +15,10 @@ permissions:
 
 jobs:
   release:
-    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-new-version.yml@v2
     with:
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: v4.0-alpha
+      action-bump-version-ref: v4
     secrets:
       GITHUB_PUSH_TOKEN: ${{ secrets.KUNGFU_GITHUB_TOKEN }}

--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   try:
-    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2.0-alpha
+    uses: kungfu-systems/workflows/.github/workflows/.release-verify.yml@v2
     with:
       prebuild: false
       build-container-enabled: false
@@ -21,7 +21,7 @@ jobs:
       publish-versioning: false
       publish-aws-ci: false
       publish-aws-user: false
-      action-bump-version-ref: v4.0-alpha
+      action-bump-version-ref: v4
   
   verify:
     needs: try

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@kungfu-trader/action-purge-artifacts",
   "version": "1.0.3-alpha.0",
   "main": "dist/index.js",
-  "repository": "https://github.com/kungfu-trader/action-purge-artifacts",
+  "repository": "https://github.com/kungfu-systems/action-purge-artifacts",
   "author": "Keren Dong",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
## Summary
- move release workflow callers from alpha foundation refs to stable workflows v2
- move action-bump-version-ref from alpha to stable v4
- update package repository metadata to kungfu-systems

## Validation
- actionlint -color=false on all workflow files
- residual scan for old owner, alpha foundation refs, and deprecated runtime markers
- git diff --check

Yarn build was not rerun because this change does not modify source or dist files and this local checkout does not have project dependencies installed.